### PR TITLE
Update to pass strings in cells longer than 8221. Using .Value rather than .Text

### DIFF
--- a/XLSM/frmMain.frm
+++ b/XLSM/frmMain.frm
@@ -426,7 +426,7 @@ Private Function GetWorksheetCSVToStream(ByRef ExportWorksheet, ByRef ObjStream 
        
        For columnNumber = 1 To ColumnCount
        
-        cellText = .Cells(rowNumber, columnNumber).Text
+        cellText = .Cells(rowNumber, columnNumber).Value
         
         If TagRow Then
             cellText = """" & Replace(cellText, """", """""") & """"


### PR DESCRIPTION
When exporting, text from original cell gets cut in length 8221 because of the .Text attribute. 
Using .Value rather than .Text fixed the issue for me. The XML cell can get pretty long.